### PR TITLE
[minor] additional functions to prevent linter complaints

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -72,8 +72,20 @@ func (a *Asserter) Assertf(actualJSON, expectedJSON string, fmtArgs ...interface
 	a.pathassertf("$", actualJSON, fmt.Sprintf(expectedJSON, fmtArgs...))
 }
 
+// Assert is identical to Assertf but without format args
+func (a *Asserter) Assert(actualJSON, expectedJSON string) {
+	a.tt.Helper()
+	a.pathassertf("$", actualJSON, expectedJSON)
+}
+
 // AssertContainsf asserts that the JSON object only contains the expected elements
 func (a *Asserter) AssertContainsf(actualJSON, expectedJSON string, fmtArgs ...interface{}) {
 	a.partial = true
 	a.Assertf(actualJSON, expectedJSON, fmtArgs...)
+}
+
+// AssertContains is identical to AssertContainsf but without format args
+func (a *Asserter) AssertContains(actualJSON, expectedJSON string) {
+	a.partial = true
+	a.Assert(actualJSON, expectedJSON)
 }


### PR DESCRIPTION
in preparation for upgrading golangci-lint using assertf gets picked up
```
printf: non-constant format string in call to (*github.com/mx51/jsonassert.Asserter).Assertf (govet)
```

so adding 2 new methods based on what the original library most likely will do based on [this issue](https://github.com/kinbiko/jsonassert/issues/45)